### PR TITLE
feat: bump atlas local plugin MinVersion in mongodb-atlas-cli automatically

### DIFF
--- a/.github/workflows/bump-atlas-cli-min-version.yml
+++ b/.github/workflows/bump-atlas-cli-min-version.yml
@@ -1,0 +1,75 @@
+name: Bump AtlasCLI Plugin MinVersion
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  bump-atlas-cli-min-version:
+    name: Bump atlas-local MinVersion in mongodb-atlas-cli
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Parse plan and set variables
+        id: parse-plan
+        run: |
+          PLAN='${{ inputs.plan }}'
+          IS_PRERELEASE=$(echo "$PLAN" | jq -r '.announcement_is_prerelease')
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            echo "Skipping: prerelease"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TAG=$(echo "$PLAN" | jq -r '.announcement_tag')
+          VERSION="${TAG#v}"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Get APIX Bot token
+        if: steps.parse-plan.outputs.skip != 'true'
+        id: app-token
+        uses: mongodb/apix-action/token@6c3fde402c21942fa46cde003f190c2b23c59530
+        with:
+          app-id: ${{ secrets.APIXBOT_APP_ID }}
+          private-key: ${{ secrets.APIXBOT_APP_PEM }}
+
+      - name: Checkout mongodb-atlas-cli
+        if: steps.parse-plan.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: mongodb/mongodb-atlas-cli
+          token: ${{ steps.app-token.outputs.token }}
+          ref: master
+
+      - name: Update atlas-local-plugin MinVersion
+        if: steps.parse-plan.outputs.skip != 'true'
+        run: |
+          VERSION="${{ steps.parse-plan.outputs.version }}"
+          FILE="internal/cli/plugin/first_class.go"
+          sed -i.bak "s/AtlasLocalPluginMinVersion = \"[^\"]*\"/AtlasLocalPluginMinVersion = \"${VERSION}\"/" "$FILE"
+          rm -f "${FILE}.bak"
+
+      - name: Create pull request
+        if: steps.parse-plan.outputs.skip != 'true'
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          committer: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
+          author: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
+          add-paths: internal/cli/plugin/first_class.go
+          title: "chore(plugin): bump atlas local plugin MinVersion to ${{ steps.parse-plan.outputs.version }}"
+          commit-message: "chore(plugin): bump atlas local plugin MinVersion to ${{ steps.parse-plan.outputs.version }}"
+          base: master
+          branch: "chore/atlas-local-plugin-min-version-${{ steps.parse-plan.outputs.version }}"
+          labels: |
+            dependencies
+          body: |
+            Bump minimum required version of the atlas local plugin to `${{ steps.parse-plan.outputs.version }}`.
+
+            Opened automatically after [atlas local plugin release ${{ steps.parse-plan.outputs.tag }}](https://github.com/mongodb/atlas-local-cli/releases/tag/${{ steps.check.outputs.tag }}).

--- a/.github/workflows/bump-atlas-cli-min-version.yml
+++ b/.github/workflows/bump-atlas-cli-min-version.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: mongodb/mongodb-atlas-cli
           token: ${{ steps.app-token.outputs.token }}
-          ref: master
+          ref: main
 
       - name: Update atlas-local-plugin MinVersion
         if: steps.parse-plan.outputs.skip != 'true'
@@ -66,7 +66,7 @@ jobs:
           add-paths: internal/cli/plugin/first_class.go
           title: "chore(plugin): bump atlas local plugin MinVersion to ${{ steps.parse-plan.outputs.version }}"
           commit-message: "chore(plugin): bump atlas local plugin MinVersion to ${{ steps.parse-plan.outputs.version }}"
-          base: master
+          base: main
           branch: "chore/atlas-local-plugin-min-version-${{ steps.parse-plan.outputs.version }}"
           labels: |
             dependencies

--- a/.github/workflows/bump-atlas-cli-min-version.yml
+++ b/.github/workflows/bump-atlas-cli-min-version.yml
@@ -15,10 +15,11 @@ jobs:
     name: Bump atlas-local MinVersion in mongodb-atlas-cli
     runs-on: ubuntu-22.04
     steps:
-      - name: Parse plan and set variables
+      - name: Check prerelease and set outputs
         id: parse-plan
+        env:
+          PLAN: ${{ inputs.plan }}
         run: |
-          PLAN='${{ inputs.plan }}'
           IS_PRERELEASE=$(echo "$PLAN" | jq -r '.announcement_is_prerelease')
           if [ "$IS_PRERELEASE" = "true" ]; then
             echo "Skipping: prerelease"
@@ -72,4 +73,4 @@ jobs:
           body: |
             Bump minimum required version of the atlas local plugin to `${{ steps.parse-plan.outputs.version }}`.
 
-            Opened automatically after [atlas local plugin release ${{ steps.parse-plan.outputs.tag }}](https://github.com/mongodb/atlas-local-cli/releases/tag/${{ steps.check.outputs.tag }}).
+            Opened automatically after [atlas local plugin release ${{ steps.parse-plan.outputs.tag }}](https://github.com/mongodb/atlas-local-cli/releases/tag/${{ steps.parse-plan.outputs.tag }}).

--- a/.github/workflows/bump-atlas-local-plugin-min-version.yml
+++ b/.github/workflows/bump-atlas-local-plugin-min-version.yml
@@ -1,4 +1,4 @@
-name: Bump AtlasCLI Plugin MinVersion
+name: Bump Atlas Local plugin minimal version
 
 on:
   workflow_call:
@@ -11,8 +11,8 @@ permissions:
   contents: write
 
 jobs:
-  bump-atlas-cli-min-version:
-    name: Bump atlas-local MinVersion in mongodb-atlas-cli
+  bump-atlas-local-plugin-min-version:
+    name: Bump Atlas Local plugin minimal version
     runs-on: ubuntu-22.04
     steps:
       - name: Check prerelease and set outputs
@@ -48,7 +48,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           ref: main
 
-      - name: Update atlas-local-plugin MinVersion
+      - name: Update Atlas Local plugin MinVersion variable
         if: steps.parse-plan.outputs.skip != 'true'
         run: |
           VERSION="${{ steps.parse-plan.outputs.version }}"
@@ -64,13 +64,13 @@ jobs:
           committer: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
           author: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
           add-paths: internal/cli/plugin/first_class.go
-          title: "chore(plugin): bump atlas local plugin MinVersion to ${{ steps.parse-plan.outputs.version }}"
-          commit-message: "chore(plugin): bump atlas local plugin MinVersion to ${{ steps.parse-plan.outputs.version }}"
+          title: "chore(plugin): bump Atlas Local plugin minimal version to ${{ steps.parse-plan.outputs.version }}"
+          commit-message: "chore(plugin): bump Atlas Local plugin minimal version to ${{ steps.parse-plan.outputs.version }}"
           base: main
           branch: "chore/atlas-local-plugin-min-version-${{ steps.parse-plan.outputs.version }}"
           labels: |
             dependencies
           body: |
-            Bump minimum required version of the atlas local plugin to `${{ steps.parse-plan.outputs.version }}`.
+            Bump minimum required version of the Atlas Local plugin to `${{ steps.parse-plan.outputs.version }}`.
 
-            Opened automatically after [atlas local plugin release ${{ steps.parse-plan.outputs.tag }}](https://github.com/mongodb/atlas-local-cli/releases/tag/${{ steps.parse-plan.outputs.tag }}).
+            Opened automatically after [Atlas Local plugin release ${{ steps.parse-plan.outputs.tag }}](https://github.com/mongodb/atlas-local-cli/releases/tag/${{ steps.parse-plan.outputs.tag }}).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,67 +316,29 @@ jobs:
       "id-token": "write"
       "packages": "write"
 
-  bump-atlas-cli-min-version:
-    name: Bump atlas-local MinVersion in mongodb-atlas-cli
+  custom-bump-atlas-cli-min-version:
     needs:
       - plan
       - host
-    if: ${{ needs.host.result == 'success' && !fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
-    runs-on: ubuntu-22.04
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    uses: ./.github/workflows/bump-atlas-cli-min-version.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    # publish jobs get escalated permissions
     permissions:
-      contents: write
-    steps:
-      - name: Get APIX Bot token
-        id: app-token
-        uses: mongodb/apix-action/token@6c3fde402c21942fa46cde003f190c2b23c59530
-        with:
-          app-id: ${{ secrets.APIXBOT_APP_ID }}
-          private-key: ${{ secrets.APIXBOT_APP_PEM }}
-      - name: Extract version from tag
-        id: version
-        run: |
-          TAG="${{ needs.plan.outputs.tag }}"
-          VERSION="${TAG#v}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-      - name: Checkout mongodb-atlas-cli
-        uses: actions/checkout@v4
-        with:
-          repository: mongodb/mongodb-atlas-cli
-          token: ${{ steps.app-token.outputs.token }}
-          ref: master
-      - name: Update atlas-local-plugin MinVersion
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          FILE="internal/cli/plugin/first_class.go"
-          sed -i.bak "s/AtlasLocalPluginMinVersion = \"[^\"]*\"/AtlasLocalPluginMinVersion = \"${VERSION}\"/" "$FILE"
-          rm -f "${FILE}.bak"
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          committer: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
-          author: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
-          add-paths: internal/cli/plugin/first_class.go
-          title: "chore(plugin): bump atlas local plugin MinVersion to ${{ steps.version.outputs.version }}"
-          commit-message: "chore(plugin): bump atlas local plugin MinVersion to ${{ steps.version.outputs.version }}"
-          base: master
-          branch: "chore/atlas-local-plugin-min-version-${{ steps.version.outputs.version }}"
-          labels: |
-            dependencies
-          body: |
-            Bump minimum required version of the atlas local plugin to `${{ steps.version.outputs.version }}`.
-
-            Opened automatically after [atlas local plugin release ${{ needs.plan.outputs.tag }}](https://github.com/mongodb/atlas-local-cli/releases/tag/${{ needs.plan.outputs.tag }}).
+      "contents": "write"
 
   announce:
     needs:
       - plan
       - host
       - custom-sign-zip
+      - custom-bump-atlas-cli-min-version
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.custom-sign-zip.result == 'skipped' || needs.custom-sign-zip.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.custom-sign-zip.result == 'skipped' || needs.custom-sign-zip.result == 'success') && (needs.custom-bump-atlas-cli-min-version.result == 'skipped' || needs.custom-bump-atlas-cli-min-version.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,6 +316,58 @@ jobs:
       "id-token": "write"
       "packages": "write"
 
+  bump-atlas-cli-min-version:
+    name: Bump atlas-local MinVersion in mongodb-atlas-cli
+    needs:
+      - plan
+      - host
+    if: ${{ needs.host.result == 'success' && !fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Get APIX Bot token
+        id: app-token
+        uses: mongodb/apix-action/token@6c3fde402c21942fa46cde003f190c2b23c59530
+        with:
+          app-id: ${{ secrets.APIXBOT_APP_ID }}
+          private-key: ${{ secrets.APIXBOT_APP_PEM }}
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Checkout mongodb-atlas-cli
+        uses: actions/checkout@v4
+        with:
+          repository: mongodb/mongodb-atlas-cli
+          token: ${{ steps.app-token.outputs.token }}
+          ref: master
+      - name: Update atlas-local-plugin MinVersion
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          FILE="internal/cli/plugin/first_class.go"
+          sed -i.bak "s/AtlasLocalPluginMinVersion = \"[^\"]*\"/AtlasLocalPluginMinVersion = \"${VERSION}\"/" "$FILE"
+          rm -f "${FILE}.bak"
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          committer: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
+          author: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
+          add-paths: internal/cli/plugin/first_class.go
+          title: "chore(plugin): bump atlas local plugin MinVersion to ${{ steps.version.outputs.version }}"
+          commit-message: "chore(plugin): bump atlas local plugin MinVersion to ${{ steps.version.outputs.version }}"
+          base: master
+          branch: "chore/atlas-local-plugin-min-version-${{ steps.version.outputs.version }}"
+          labels: |
+            dependencies
+          body: |
+            Bump minimum required version of the atlas local plugin to `${{ steps.version.outputs.version }}`.
+
+            Opened automatically after [atlas local plugin release ${{ needs.plan.outputs.tag }}](https://github.com/mongodb/atlas-local-cli/releases/tag/${{ needs.plan.outputs.tag }}).
+
   announce:
     needs:
       - plan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,29 +316,15 @@ jobs:
       "id-token": "write"
       "packages": "write"
 
-  custom-bump-atlas-cli-min-version:
-    needs:
-      - plan
-      - host
-    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    uses: ./.github/workflows/bump-atlas-cli-min-version.yml
-    with:
-      plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
-    # publish jobs get escalated permissions
-    permissions:
-      "contents": "write"
-
   announce:
     needs:
       - plan
       - host
       - custom-sign-zip
-      - custom-bump-atlas-cli-min-version
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.custom-sign-zip.result == 'skipped' || needs.custom-sign-zip.result == 'success') && (needs.custom-bump-atlas-cli-min-version.result == 'skipped' || needs.custom-bump-atlas-cli-min-version.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.custom-sign-zip.result == 'skipped' || needs.custom-sign-zip.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -347,3 +333,12 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+
+  custom-bump-atlas-local-plugin-min-version:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/bump-atlas-local-plugin-min-version.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit

--- a/.github/workflows/sign-zip.yml
+++ b/.github/workflows/sign-zip.yml
@@ -25,10 +25,9 @@ jobs:
 
       - name: Parse plan and set variables
         id: parse-plan
+        env:
+          PLAN: ${{ inputs.plan }}
         run: |
-          # Parse the plan JSON to extract release information
-          PLAN='${{ inputs.plan }}'
-          
           # Extract release tag
           TAG=$(echo "$PLAN" | jq -r '.announcement_tag')
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -26,8 +26,9 @@ install-updater = false
 # Whether to use cargo-cyclonedx to generate an SBOM
 cargo-cyclonedx = true
 # Publish jobs to run in CI
-publish-jobs = ["./sign-zip", "./bump-atlas-cli-min-version"]
-
+publish-jobs = ["./sign-zip"]
+# Post-announce jobs to run in CI
+post-announce-jobs = ["./bump-atlas-local-plugin-min-version"]
 # Add contents:write permission for publish jobs (needed to upload release assets)
 # Note: overriding removes defaults, so we include id-token and packages too
 github-custom-job-permissions = { "sign-zip" = { contents = "write", id-token = "write", packages = "write" }, "bump-atlas-cli-min-version" = { contents = "write" } }

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -26,11 +26,11 @@ install-updater = false
 # Whether to use cargo-cyclonedx to generate an SBOM
 cargo-cyclonedx = true
 # Publish jobs to run in CI
-publish-jobs = ["./sign-zip"]
+publish-jobs = ["./sign-zip", "./bump-atlas-cli-min-version"]
 
 # Add contents:write permission for publish jobs (needed to upload release assets)
 # Note: overriding removes defaults, so we include id-token and packages too
-github-custom-job-permissions = { "sign-zip" = { contents = "write", id-token = "write", packages = "write" } }
+github-custom-job-permissions = { "sign-zip" = { contents = "write", id-token = "write", packages = "write" }, "bump-atlas-cli-min-version" = { contents = "write" } }
 
 [dist.dependencies.apt]
 libdbus-1-dev = '*'


### PR DESCRIPTION
Add a new step to the release process to create a [PR like this one in the mongodb-atlas-cli repo](https://github.com/mongodb/mongodb-atlas-cli/pull/4482) to update the minimum version of atlas local plugin in the next AtlasCLI release.

Flyby: Semgrep's suggestion also applies to sign-zip.yml so fixed it there too