### PR TITLE
fix: update rustls-webpki to 0.103.12 (RUSTSEC-2026-0098)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -7816,7 +7816,7 @@ PERFORMANCE OF THIS SOFTWARE.
 -----------------------------------------------------------------------------
                         ISC License
         applies to: 
-        - rustls-webpki 0.103.10 (https://github.com/rustls/webpki)
+        - rustls-webpki 0.103.12 (https://github.com/rustls/webpki)
 -----------------------------------------------------------------------------
 
 Except as otherwise noted, this project is licensed under the following


### PR DESCRIPTION
## Summary

- Bumps `rustls-webpki` from `0.103.10` to `0.103.12` via `cargo update -p rustls-webpki`
- Fixes RUSTSEC-2026-0098 / GHSA-965h-392x-2mh5: URI name constraints were incorrectly accepted after signature verification
- Closes #58

## Test plan

- [ ] Security audit CI passes after this change