### PR TITLE
chore(deps): bump atlas-local from 0.6.0 to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "atlas-local"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d1b3523687302d8b50932f10ebd296c0042d105efbd333debafbdf10711d3e"
+checksum = "b822617b3d33f3b82308f74d47a967322f58393f266645841617e9984c341ede"
 dependencies = [
  "bollard",
  "bytes",
@@ -138,7 +138,7 @@ version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "atlas-local 0.6.0",
+ "atlas-local 0.6.1",
  "bollard",
  "bytes",
  "clap",
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ generate-manifest = []
 [dependencies]
 anyhow = "1.0.102"
 async-trait = "0.1.89"
-atlas-local = "0.6.0"
+atlas-local = "0.6.1"
 bollard = "0.20"
 clap = { version = "4.5.60", features = ["derive"] }
 console = "0.16.2"

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -1,15 +1,3 @@
-2026-04-21 9:21:15.075822 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
-2026-04-21 9:21:15.106522 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
-2026-04-21 9:21:15.492836 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
-2026-04-21 9:21:17.186055 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
-2026-04-21 9:21:17.461617 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
-2026-04-21 9:21:17.781178 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
 THIRD PARTY LICENSES
 ====================
 

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -1,3 +1,15 @@
+2026-04-21 9:21:15.075822 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
+2026-04-21 9:21:15.106522 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
+2026-04-21 9:21:15.492836 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
+2026-04-21 9:21:17.186055 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
+2026-04-21 9:21:17.461617 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
+2026-04-21 9:21:17.781178 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
 THIRD PARTY LICENSES
 ====================
 
@@ -2159,7 +2171,7 @@ OVERVIEW OF LICENSES:
                         Apache License 2.0
         applies to: 
         - atlas-local 0.11.1 (https://github.com/mongodb/atlas-local-cli/)
-        - atlas-local 0.6.0 (https://github.com/mongodb/atlas-local-lib)
+        - atlas-local 0.6.1 (https://github.com/mongodb/atlas-local-lib)
         - content_inspector 0.2.4 (https://github.com/sharkdp/content_inspector)
 -----------------------------------------------------------------------------
 
@@ -7236,7 +7248,7 @@ END OF TERMS AND CONDITIONS
 -----------------------------------------------------------------------------
                         Apache License 2.0
         applies to: 
-        - chrono 0.4.43 (https://github.com/chronotope/chrono)
+        - chrono 0.4.44 (https://github.com/chronotope/chrono)
 -----------------------------------------------------------------------------
 
 Rust-chrono is dual-licensed under The MIT License [1] and


### PR DESCRIPTION
Bumps `atlas-local` from 0.6.0 to 0.6.1.

## Changes in 0.6.1
- Reject image field when it includes a tag ([#99](https://github.com/mongodb/atlas-local-lib/pull/99))
- Improve release workflow ([#83](https://github.com/mongodb/atlas-local-lib/pull/83))

## Why a separate PR?
The dependabot PR [#63](https://github.com/mongodb/atlas-local-cli/pull/63) bundles this with a `bollard 0.20.1 → 0.20.2` bump that introduces a breaking change (Docker structs made private). This PR isolates the `atlas-local` bump so it can land independently.