### PR TITLE
fix: bump atlas-local to 0.7.1, drop direct bollard dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atlas-local 0.7.1",
- "bollard",
  "bytes",
  "clap",
  "console",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -50,15 +50,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "atlas-local"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b822617b3d33f3b82308f74d47a967322f58393f266645841617e9984c341ede"
+checksum = "679cd28955e6e4c120b01d225f0b60f686ca50536e21dfd8232750d25cad98fb"
 dependencies = [
  "bollard",
  "bytes",
@@ -138,7 +138,7 @@ version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "atlas-local 0.6.1",
+ "atlas-local 0.7.1",
  "bollard",
  "bytes",
  "clap",
@@ -162,7 +162,7 @@ dependencies = [
  "typed-builder 0.23.2",
  "url",
  "which",
- "winreg 0.55.0",
+ "winreg 0.56.0",
 ]
 
 [[package]]
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227aa051deec8d16bd9c34605e7aaf153f240e35483dd42f6f78903847934738"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
 dependencies = [
  "base64",
  "bollard-stubs",
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.52.1-rc.29.1.3"
+version = "1.53.1-rc.29.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
 dependencies = [
  "serde",
  "serde_json",
@@ -288,6 +288,16 @@ dependencies = [
  "serde_json",
  "time",
  "uuid",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -350,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -360,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -372,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -395,6 +405,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "config"
 version = "0.15.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,19 +430,18 @@ dependencies = [
  "serde_core",
  "serde_json",
  "toml",
- "winnow",
+ "winnow 0.7.14",
  "yaml-rust2",
 ]
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
@@ -792,16 +811,16 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duration-str"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae065b0fbd186e5014e14be5f9411e4cb4a2ec14168e8a34e38183a3d1c07544"
+checksum = "027cd1402a609c71a9ac333c7e3d90ee042e7a131da1a83da8c60df323f12f61"
 dependencies = [
  "chrono",
  "rust_decimal",
  "serde",
  "thiserror",
  "time",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -830,24 +849,6 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1129,23 +1130,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -1154,21 +1154,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration",
  "thiserror",
  "tokio",
  "tracing",
@@ -1511,6 +1536,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1523,6 +1551,55 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -1575,9 +1652,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -1611,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1796,9 +1873,9 @@ checksum = "224484c5d09285a7b8cb0a0c117e847ebd14cb6e4470ecf68cdb89c503b0edb9"
 
 [[package]]
 name = "mongodb"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803dd859e8afa084c255a8effd8000ff86f7c8076a50cd6d8c99e8f3496f75c2"
+checksum = "276ba0cd571553d1f6936c6f180964776ece6ab7507dc8765f8a9c9c49d8cd00"
 dependencies = [
  "base64",
  "bitflags",
@@ -1809,6 +1886,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hex",
+ "hickory-net",
  "hickory-proto",
  "hickory-resolver",
  "hmac",
@@ -1821,7 +1899,6 @@ dependencies = [
  "rand 0.9.4",
  "rustc_version_runtime",
  "rustls",
- "rustversion",
  "serde",
  "serde_bytes",
  "serde_with",
@@ -1858,15 +1935,21 @@ dependencies = [
 
 [[package]]
 name = "mongodb-internal-macros"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973ef3dd3dbc6f6e65bbdecfd9ec5e781b9e7493b0f369a7c62e35d8e5ae2c8"
+checksum = "99ceb1a9a1018e470077ec94cf3a8c2d0e6da542b2c05ea95a59a0a627147375"
 dependencies = [
  "macro_magic",
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "normalize-line-endings"
@@ -2102,6 +2185,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2328,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -2439,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -2501,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2526,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -2636,10 +2730,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "similar"
-version = "2.7.0"
+name = "simd_cesu8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "slab"
@@ -2655,9 +2768,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snapbox"
-version = "1.0.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d70a71b68054cbe88708f77abfc4bd2daf75028f8f55f4f1cff63565df89ea"
+checksum = "8de56eb4784a2c5c1efede55a0f06fbf481bc12b42b355b9525c15db1e3581a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2672,14 +2785,14 @@ dependencies = [
  "tempfile",
  "wait-timeout",
  "walkdir",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "snapbox-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d248cef42e1456ab2f7149c0376985351b7d849ea9ad2a957bf15ddfebf1fdf9"
+checksum = "ed4a172e483585ebbc7c7f7d1705ca7e3f94f606ed78caa14805673189fd5455"
 dependencies = [
  "anstream",
 ]
@@ -2735,9 +2848,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2753,6 +2866,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2775,12 +2909,11 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2888,9 +3021,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2934,6 +3067,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2947,10 +3081,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -2963,34 +3097,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower-service"
@@ -3043,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3067,9 +3210,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trycmd"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e34125a48d61da3907f391dffc3aa91cad42e8e2dc94a2dc03ec76fe707ced"
+checksum = "218889993f76bda9b2ef57c12c3cab0eef4fd54ec7b36d1704849867f69e7bb4"
 dependencies = [
  "anstream",
  "automod",
@@ -3398,13 +3541,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -3744,6 +3885,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3755,19 +3905,13 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,29 +14,29 @@ generate-manifest = []
 [dependencies]
 anyhow = "1.0.102"
 async-trait = "0.1.89"
-atlas-local = "0.6.1"
-bollard = "0.20"
-clap = { version = "4.5.60", features = ["derive"] }
-console = "0.16.2"
-duration-str = "0.20.0"
+atlas-local = { version = "0.7.1", features = ["bollard"] }
+bollard = "0.21"
+clap = { version = "4.6.1", features = ["derive"] }
+console = "0.16.3"
+duration-str = "0.21.0"
 futures = "0.3.32"
 indicatif = "0.18.4"
 inquire = "0.9.4"
-mongodb = "3.5.1"
+mongodb = "3.7.0"
 mongodb-atlas-cli = "0.0.2"
-semver = { version = "1.0.27", features = ["serde"] }
+semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
+serde_json = "1.0.150"
 thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 typed-builder = "0.23.2"
 url = "2.5.8"
-which = "8.0.0"
+which = "8.0.2"
 
 [target.'cfg(windows)'.dependencies]
-winreg = "0.55"
+winreg = "0.56"
 
 # The profile that 'dist' will build with
 [profile.dist]
@@ -48,8 +48,8 @@ bytes = "1.11"
 futures = "0.3.32"
 futures-util = "0.3.31"
 mockall = "0.14.0"
-trycmd = "1.0.0"
-which = "8.0.0"
+trycmd = "1.1.1"
+which = "8.0.2"
 
 [[bin]]
 name = "atlas-local-docs-generator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ generate-manifest = []
 anyhow = "1.0.102"
 async-trait = "0.1.89"
 atlas-local = { version = "0.7.1", features = ["bollard"] }
-bollard = "0.21"
 clap = { version = "4.6.1", features = ["derive"] }
 console = "0.16.3"
 duration-str = "0.21.0"

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -1,15 +1,3 @@
-2026-05-27 14:04:03.698385 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
-2026-05-27 14:04:03.720089 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
-2026-05-27 14:04:04.034195 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
-2026-05-27 14:04:05.277825 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
-2026-05-27 14:04:05.437492 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
-2026-05-27 14:04:05.708326 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
-^^^^^^^ a deprecated license identifier was used[0m
 THIRD PARTY LICENSES
 ====================
 

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -1,11 +1,23 @@
+2026-05-27 14:04:03.698385 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
+2026-05-27 14:04:03.720089 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
+2026-05-27 14:04:04.034195 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
+2026-05-27 14:04:05.277825 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
+2026-05-27 14:04:05.437492 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
+2026-05-27 14:04:05.708326 +00:00:00 [[31mERROR[0m] failed to parse license 'GPL-2.0' into a valid expression: GPL-2.0
+^^^^^^^ a deprecated license identifier was used[0m
 THIRD PARTY LICENSES
 ====================
 
 This file lists the licenses of the projects used in atlas-local-lib.
 
 OVERVIEW OF LICENSES:
-- Apache License 2.0 (291 dependencies)
-- MIT License (72 dependencies)
+- Apache License 2.0 (301 dependencies)
+- MIT License (73 dependencies)
 - Unicode License v3 (19 dependencies)
 - ISC License (4 dependencies)
 - BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License (2 dependencies)
@@ -650,7 +662,6 @@ OVERVIEW OF LICENSES:
         - derive-where 1.6.0 (https://github.com/ModProg/derive-where)
         - encode_unicode 1.0.0 (https://github.com/tormol/encode_unicode)
         - encoding_rs 0.8.35 (https://github.com/hsivonen/encoding_rs)
-        - env_home 0.1.0 (https://github.com/notpeter/env-home)
         - fragile 2.0.1 (https://github.com/mitsuhiko/fragile)
         - tinyvec 1.10.0 (https://github.com/Lokathor/tinyvec)
         - utf8_iter 1.0.4 (https://github.com/hsivonen/utf8_iter)
@@ -1110,7 +1121,7 @@ OVERVIEW OF LICENSES:
 -----------------------------------------------------------------------------
                         Apache License 2.0
         applies to: 
-        - bollard 0.20.1 (https://github.com/fussybeaver/bollard)
+        - bollard 0.21.0 (https://github.com/fussybeaver/bollard)
         - hyper-named-pipe 0.1.0 (https://github.com/fussybeaver/hyper-named-pipe)
 -----------------------------------------------------------------------------
 
@@ -2159,7 +2170,7 @@ OVERVIEW OF LICENSES:
                         Apache License 2.0
         applies to: 
         - atlas-local 0.11.2 (https://github.com/mongodb/atlas-local-cli/)
-        - atlas-local 0.6.1 (https://github.com/mongodb/atlas-local-lib)
+        - atlas-local 0.7.1 (https://github.com/mongodb/atlas-local-lib)
         - content_inspector 0.2.4 (https://github.com/sharkdp/content_inspector)
 -----------------------------------------------------------------------------
 
@@ -2370,6 +2381,7 @@ OVERVIEW OF LICENSES:
                         Apache License 2.0
         applies to: 
         - ipnet 2.11.0 (https://github.com/krisprice/ipnet)
+        - prefix-trie 0.8.4 (https://github.com/tiborschneider/prefix-trie)
 -----------------------------------------------------------------------------
 
                                  Apache License
@@ -2791,33 +2803,34 @@ OVERVIEW OF LICENSES:
 -----------------------------------------------------------------------------
                         Apache License 2.0
         applies to: 
-        - anstream 0.6.21 (https://github.com/rust-cli/anstyle.git)
-        - anstyle-parse 0.2.7 (https://github.com/rust-cli/anstyle.git)
+        - anstream 1.0.0 (https://github.com/rust-cli/anstyle.git)
+        - anstyle-parse 1.0.0 (https://github.com/rust-cli/anstyle.git)
         - anstyle-query 1.1.5 (https://github.com/rust-cli/anstyle.git)
         - anstyle-wincon 3.0.11 (https://github.com/rust-cli/anstyle.git)
-        - anstyle 1.0.13 (https://github.com/rust-cli/anstyle.git)
-        - clap 4.5.60 (https://github.com/clap-rs/clap)
-        - clap_builder 4.5.60 (https://github.com/clap-rs/clap)
-        - clap_derive 4.5.55 (https://github.com/clap-rs/clap)
+        - anstyle 1.0.14 (https://github.com/rust-cli/anstyle.git)
+        - clap 4.6.1 (https://github.com/clap-rs/clap)
+        - clap_builder 4.6.0 (https://github.com/clap-rs/clap)
+        - clap_derive 4.6.1 (https://github.com/clap-rs/clap)
         - clap_lex 1.0.0 (https://github.com/clap-rs/clap)
         - colorchoice 1.0.4 (https://github.com/rust-cli/anstyle.git)
         - config 0.15.19 (https://github.com/rust-cli/config-rs)
-        - enum-as-inner 0.6.1 (https://github.com/bluejekyll/enum-as-inner)
         - hex 0.4.3 (https://github.com/KokaKiwi/rust-hex)
         - humantime 2.3.0 (https://github.com/chronotope/humantime)
         - is_terminal_polyfill 1.70.2 (https://github.com/polyfill-rs/is_terminal_polyfill)
+        - jni-sys 0.4.1 (https://github.com/jni-rs/jni-sys)
         - once_cell_polyfill 1.70.2 (https://github.com/polyfill-rs/once_cell_polyfill)
         - resolv-conf 0.7.6 (https://github.com/hickory-dns/resolv-conf)
-        - serde_spanned 1.0.4 (https://github.com/toml-rs/toml)
-        - snapbox-macros 1.0.0 (https://github.com/assert-rs/snapbox/)
-        - snapbox 1.0.0 (https://github.com/assert-rs/snapbox/)
+        - serde_spanned 1.1.1 (https://github.com/toml-rs/toml)
+        - snapbox-macros 1.1.0 (https://github.com/assert-rs/snapbox/)
+        - snapbox 1.2.2 (https://github.com/assert-rs/snapbox/)
         - stringprep 0.1.5 (https://github.com/sfackler/rust-stringprep)
         - toml 0.9.11+spec-1.1.0 (https://github.com/toml-rs/toml)
         - toml_datetime 0.7.5+spec-1.1.0 (https://github.com/toml-rs/toml)
-        - toml_edit 0.23.10+spec-1.0.0 (https://github.com/toml-rs/toml)
-        - toml_parser 1.0.6+spec-1.1.0 (https://github.com/toml-rs/toml)
-        - toml_writer 1.0.6+spec-1.1.0 (https://github.com/toml-rs/toml)
-        - trycmd 1.0.0 (https://github.com/assert-rs/snapbox/)
+        - toml_datetime 1.1.1+spec-1.1.0 (https://github.com/toml-rs/toml)
+        - toml_edit 0.25.11+spec-1.1.0 (https://github.com/toml-rs/toml)
+        - toml_parser 1.1.2+spec-1.1.0 (https://github.com/toml-rs/toml)
+        - toml_writer 1.1.1+spec-1.1.0 (https://github.com/toml-rs/toml)
+        - trycmd 1.2.0 (https://github.com/assert-rs/snapbox/)
 -----------------------------------------------------------------------------
 
                                  Apache License
@@ -3027,8 +3040,9 @@ OVERVIEW OF LICENSES:
 -----------------------------------------------------------------------------
                         Apache License 2.0
         applies to: 
-        - hickory-proto 0.25.2 (https://github.com/hickory-dns/hickory-dns)
-        - hickory-resolver 0.25.2 (https://github.com/hickory-dns/hickory-dns)
+        - hickory-net 0.26.1 (https://github.com/hickory-dns/hickory-dns)
+        - hickory-proto 0.26.1 (https://github.com/hickory-dns/hickory-dns)
+        - hickory-resolver 0.26.1 (https://github.com/hickory-dns/hickory-dns)
 -----------------------------------------------------------------------------
 
                                  Apache License
@@ -5378,7 +5392,7 @@ limitations under the License.
         - ipconfig 0.3.2 (https://github.com/liranringel/ipconfig)
         - js-sys 0.3.85 (https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys)
         - lazy_static 1.5.0 (https://github.com/rust-lang-nursery/lazy-static.rs)
-        - linux-raw-sys 0.11.0 (https://github.com/sunfishcode/linux-raw-sys)
+        - linux-raw-sys 0.12.1 (https://github.com/sunfishcode/linux-raw-sys)
         - lock_api 0.4.14 (https://github.com/Amanieu/parking_lot)
         - log 0.4.29 (https://github.com/rust-lang/log)
         - maplit 1.0.2 (https://github.com/bluss/maplit)
@@ -5401,7 +5415,7 @@ limitations under the License.
         - ring 0.17.14 (https://github.com/briansmith/ring)
         - ron 0.12.0 (https://github.com/ron-rs/ron)
         - rustc_version 0.4.1 (https://github.com/djc/rustc-version-rs)
-        - rustix 1.1.3 (https://github.com/bytecodealliance/rustix)
+        - rustix 1.1.4 (https://github.com/bytecodealliance/rustix)
         - rustls 0.23.36 (https://github.com/rustls/rustls)
         - scopeguard 1.2.0 (https://github.com/bluss/scopeguard)
         - security-framework-sys 2.15.0 (https://github.com/kornelski/rust-security-framework)
@@ -5411,12 +5425,15 @@ limitations under the License.
         - signal-hook-mio 0.2.5 (https://github.com/vorner/signal-hook)
         - signal-hook-registry 1.4.8 (https://github.com/vorner/signal-hook)
         - signal-hook 0.3.18 (https://github.com/vorner/signal-hook)
-        - similar 2.7.0 (https://github.com/mitsuhiko/similar)
+        - simd_cesu8 1.1.1 (https://github.com/seancroach/simd_cesu8)
+        - similar 3.1.1 (https://github.com/mitsuhiko/similar)
         - smallvec 1.15.1 (https://github.com/servo/rust-smallvec)
         - socket2 0.5.10 (https://github.com/rust-lang/socket2)
         - socket2 0.6.2 (https://github.com/rust-lang/socket2)
         - stable_deref_trait 1.2.1 (https://github.com/storyyeller/stable_deref_trait)
-        - tempfile 3.24.0 (https://github.com/Stebalien/tempfile)
+        - system-configuration-sys 0.6.0 (https://github.com/mullvad/system-configuration-rs)
+        - system-configuration 0.7.0 (https://github.com/mullvad/system-configuration-rs)
+        - tempfile 3.27.0 (https://github.com/Stebalien/tempfile)
         - thread_local 1.1.9 (https://github.com/Amanieu/thread_local-rs)
         - typed-builder-macro 0.22.0 (https://github.com/idanarye/rust-typed-builder)
         - typed-builder-macro 0.23.2 (https://github.com/idanarye/rust-typed-builder)
@@ -6906,42 +6923,47 @@ limitations under the License.
         - arraydeque 0.5.1 (https://github.com/andylokandy/arraydeque)
         - async-trait 0.1.89 (https://github.com/dtolnay/async-trait)
         - automod 1.0.16 (https://github.com/dtolnay/automod)
-        - bollard-stubs 1.52.1-rc.29.1.3 (https://crates.io/crates/bollard-stubs)
+        - bollard-stubs 1.53.1-rc.29.3.1 (https://crates.io/crates/bollard-stubs)
         - dirs-sys 0.5.0 (https://github.com/dirs-dev/dirs-sys-rs)
         - dirs 6.0.0 (https://github.com/soc/dirs-rs)
         - document-features 0.2.12 (https://github.com/slint-ui/document-features)
         - dunce 1.0.5 (https://gitlab.com/kornelski/dunce)
-        - duration-str 0.20.0 (https://github.com/baoyachi/duration-str)
+        - duration-str 0.21.0 (https://github.com/baoyachi/duration-str)
         - dyn-clone 1.0.20 (https://github.com/dtolnay/dyn-clone)
         - erased-serde 0.4.9 (https://github.com/dtolnay/erased-serde)
         - ident_case 1.0.1 (https://github.com/TedDriggs/ident_case)
         - itoa 1.0.17 (https://github.com/dtolnay/itoa)
-        - libc 0.2.180 (https://github.com/rust-lang/libc)
+        - jni-macros 0.22.4 (https://github.com/jni-rs/jni-rs)
+        - jni-sys-macros 0.4.1 (https://github.com/jni-rs/jni-sys)
+        - jni 0.22.4 (https://github.com/jni-rs/jni-rs)
+        - libc 0.2.186 (https://github.com/rust-lang/libc)
         - linux-keyutils 0.2.4 (https://github.com/landhb/linux-keyutils)
         - litrs 1.0.0 (https://github.com/LukasKalbertodt/litrs)
-        - mongodb-internal-macros 3.5.1 (https://github.com/mongodb/mongo-rust-driver)
-        - mongodb 3.5.1 (https://github.com/mongodb/mongo-rust-driver)
+        - mongodb-internal-macros 3.7.0 (https://github.com/mongodb/mongo-rust-driver)
+        - mongodb 3.7.0 (https://github.com/mongodb/mongo-rust-driver)
+        - ndk-context 0.1.1 (https://github.com/rust-windowing/android-ndk-rs)
         - pin-project-lite 0.2.16 (https://github.com/taiki-e/pin-project-lite)
         - portable-atomic 1.13.0 (https://github.com/taiki-e/portable-atomic)
         - proc-macro2 1.0.106 (https://github.com/dtolnay/proc-macro2)
-        - quote 1.0.44 (https://github.com/dtolnay/quote)
+        - quote 1.0.45 (https://github.com/dtolnay/quote)
         - r-efi 5.3.0 (https://github.com/r-efi/r-efi)
         - rand 0.10.1 (https://github.com/rust-random/rand)
         - rand 0.9.4 (https://github.com/rust-random/rand)
         - rand_chacha 0.9.0 (https://github.com/rust-random/rand)
         - rustversion 1.0.22 (https://github.com/dtolnay/rustversion)
         - ryu 1.0.22 (https://github.com/dtolnay/ryu)
-        - semver 1.0.27 (https://github.com/dtolnay/semver)
+        - semver 1.0.28 (https://github.com/dtolnay/semver)
         - serde-untagged 0.1.9 (https://github.com/dtolnay/serde-untagged)
         - serde 1.0.228 (https://github.com/serde-rs/serde)
         - serde_bytes 0.11.19 (https://github.com/serde-rs/bytes)
         - serde_core 1.0.228 (https://github.com/serde-rs/serde)
         - serde_derive 1.0.228 (https://github.com/serde-rs/serde)
-        - serde_json 1.0.149 (https://github.com/serde-rs/json)
+        - serde_json 1.0.150 (https://github.com/serde-rs/json)
         - serde_repr 0.1.20 (https://github.com/dtolnay/serde-repr)
         - serde_urlencoded 0.7.1 (https://github.com/nox/serde_urlencoded)
         - shlex 1.3.0 (https://github.com/comex/rust-shlex)
-        - syn 2.0.114 (https://github.com/dtolnay/syn)
+        - simdutf8 0.1.5 (https://github.com/rusticstuff/simdutf8)
+        - syn 2.0.117 (https://github.com/dtolnay/syn)
         - tagptr 0.2.0 (https://github.com/oliver-giersch/tagptr.git)
         - thiserror-impl 2.0.18 (https://github.com/dtolnay/thiserror)
         - thiserror 2.0.18 (https://github.com/dtolnay/thiserror)
@@ -7816,7 +7838,7 @@ PERFORMANCE OF THIS SOFTWARE.
 -----------------------------------------------------------------------------
                         ISC License
         applies to: 
-        - rustls-webpki 0.103.12 (https://github.com/rustls/webpki)
+        - rustls-webpki 0.103.13 (https://github.com/rustls/webpki)
 -----------------------------------------------------------------------------
 
 Except as otherwise noted, this project is licensed under the following
@@ -7898,7 +7920,7 @@ THE SOFTWARE.
                         MIT License
         applies to: 
         - winreg 0.50.0 (https://github.com/gentoo90/winreg-rs)
-        - winreg 0.55.0 (https://github.com/gentoo90/winreg-rs)
+        - winreg 0.56.0 (https://github.com/gentoo90/winreg-rs)
 -----------------------------------------------------------------------------
 
 Copyright (c) 2015 Igor Shaula
@@ -7925,7 +7947,7 @@ THE SOFTWARE.
 -----------------------------------------------------------------------------
                         MIT License
         applies to: 
-        - which 8.0.0 (https://github.com/harryfei/which-rs.git)
+        - which 8.0.2 (https://github.com/harryfei/which-rs.git)
 -----------------------------------------------------------------------------
 
 Copyright (c) 2015 fangyuanziti
@@ -8189,7 +8211,7 @@ SOFTWARE.
         - tracing-attributes 0.1.31 (https://github.com/tokio-rs/tracing)
         - tracing-core 0.1.36 (https://github.com/tokio-rs/tracing)
         - tracing-log 0.2.0 (https://github.com/tokio-rs/tracing)
-        - tracing-subscriber 0.3.22 (https://github.com/tokio-rs/tracing)
+        - tracing-subscriber 0.3.23 (https://github.com/tokio-rs/tracing)
         - tracing 0.1.44 (https://github.com/tokio-rs/tracing)
 -----------------------------------------------------------------------------
 
@@ -8318,32 +8340,6 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-
------------------------------------------------------------------------------
-                        MIT License
-        applies to: 
-        - winsafe 0.0.19 (https://github.com/rodrigocfd/winsafe)
------------------------------------------------------------------------------
-
-Copyright (c) 2019-present, Rodrigo Cesar de Freitas Dias
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 -----------------------------------------------------------------------------
                         MIT License
@@ -8821,7 +8817,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
                         MIT License
         applies to: 
         - tokio-util 0.7.18 (https://github.com/tokio-rs/tokio)
-        - tokio 1.49.0 (https://github.com/tokio-rs/tokio)
+        - tokio 1.50.0 (https://github.com/tokio-rs/tokio)
 -----------------------------------------------------------------------------
 
 MIT License
@@ -8929,6 +8925,7 @@ DEALINGS IN THE SOFTWARE.
                         MIT License
         applies to: 
         - winnow 0.7.14 (https://github.com/winnow-rs/winnow)
+        - winnow 1.0.3 (https://github.com/winnow-rs/winnow)
 -----------------------------------------------------------------------------
 
 Permission is hereby granted, free of charge, to any person obtaining
@@ -9011,6 +9008,36 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+-----------------------------------------------------------------------------
+                        MIT License
+        applies to: 
+        - combine 4.6.7 (https://github.com/Marwes/combine)
+-----------------------------------------------------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Markus Westerlind
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
 
 
 -----------------------------------------------------------------------------
@@ -9165,7 +9192,7 @@ THE SOFTWARE.
 -----------------------------------------------------------------------------
                         MIT License
         applies to: 
-        - console 0.16.2 (https://github.com/console-rs/console)
+        - console 0.16.3 (https://github.com/console-rs/console)
         - indicatif 0.18.4 (https://github.com/console-rs/indicatif)
 -----------------------------------------------------------------------------
 

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -333,8 +333,7 @@ mod tests {
         client::{StartDeploymentError, UnpauseDeploymentError, WatchDeploymentError},
         models::{Deployment as AtlasDeployment, IntoDeploymentError},
     };
-    use bollard::errors::Error as BollardError;
-    use bollard::secret::HealthStatusEnum;
+    use atlas_local::{ContainerHealthStatus, DockerError};
     use mockall::mock;
     use semver::Version;
     use std::io;
@@ -632,9 +631,7 @@ mod tests {
             .expect_get_deployment()
             .withf(move |name| name == &deployment_name_clone)
             .return_once(|_| {
-                Err(GetDeploymentError::ContainerInspect(BollardError::from(
-                    io::Error::new(io::ErrorKind::NotFound, "container not found"),
-                )))
+                Err(GetDeploymentError::ContainerInspect(DockerError::NotFound))
             });
 
         let mut connect_command = Connect {
@@ -882,10 +879,7 @@ mod tests {
             .withf(move |id| id == &container_id_for_connection)
             .return_once(|_| {
                 Err(atlas_local::GetConnectionStringError::GetDeployment(
-                    GetDeploymentError::ContainerInspect(BollardError::from(io::Error::new(
-                        io::ErrorKind::Other,
-                        "failed to get connection string",
-                    ))),
+                    GetDeploymentError::ContainerInspect(DockerError::ServerError),
                 ))
             });
 
@@ -1554,7 +1548,7 @@ mod tests {
             .return_once(|name, _| {
                 Err(WatchDeploymentError::UnhealthyDeployment {
                     deployment_name: name.to_string(),
-                    status: HealthStatusEnum::UNHEALTHY,
+                    status: ContainerHealthStatus::Unhealthy,
                 })
             });
 

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -335,7 +335,6 @@ mod tests {
     };
     use mockall::mock;
     use semver::Version;
-    use std::io;
 
     mock! {
         pub Connector {}

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -327,12 +327,12 @@ mod tests {
     use crate::dependencies::mocks::MockDocker;
     use crate::interaction::MultiStepSpinner;
     use crate::interaction::mocks::MockInteraction;
+    use atlas_local::{ContainerHealthStatus, DockerError};
     use atlas_local::{
         GetDeploymentError,
         client::{StartDeploymentError, UnpauseDeploymentError, WatchDeploymentError},
         models::{Deployment as AtlasDeployment, IntoDeploymentError},
     };
-    use atlas_local::{ContainerHealthStatus, DockerError};
     use mockall::mock;
     use semver::Version;
     use std::io;
@@ -629,9 +629,7 @@ mod tests {
         mock_deployment_management
             .expect_get_deployment()
             .withf(move |name| name == &deployment_name_clone)
-            .return_once(|_| {
-                Err(GetDeploymentError::ContainerInspect(DockerError::NotFound))
-            });
+            .return_once(|_| Err(GetDeploymentError::ContainerInspect(DockerError::NotFound)));
 
         let mut connect_command = Connect {
             deployment_name: deployment_name.clone(),

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -7,7 +7,6 @@ use atlas_local::{
     client::WatchDeploymentError,
     models::{State, WatchOptions},
 };
-use bollard::Docker;
 use serde::Serialize;
 use tracing::debug;
 
@@ -98,7 +97,7 @@ impl TryFrom<args::Connect> for Connect {
             deployment_name: args.deployment_name,
             connector: args.connect_with,
             interaction: Box::new(Interaction::new()),
-            deployment_inspector: Box::new(Client::new(Docker::connect_with_defaults()?)),
+            deployment_inspector: Box::new(Client::connect_with_defaults()?),
             connectors: HashMap::from([
                 (
                     ConnectWith::Compass,

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -36,7 +36,9 @@ impl TryFrom<args::Delete> for Delete {
             force: args.force,
 
             interaction: Box::new(Interaction::new()),
-            deployment_deleter: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
+            deployment_deleter: Box::new(
+                Client::connect_with_defaults().context("connecting to Docker")?,
+            ),
         })
     }
 }
@@ -358,7 +360,9 @@ mod tests {
 
         let mut mock_deleter = MockDocker::new();
         mock_deleter.expect_delete().return_once(|_| {
-            Err(DeleteDeploymentError::ContainerStop(DockerError::ServerError))
+            Err(DeleteDeploymentError::ContainerStop(
+                DockerError::ServerError,
+            ))
         });
 
         let mut delete_command = Delete {
@@ -393,7 +397,9 @@ mod tests {
 
         let mut mock_deleter = MockDocker::new();
         mock_deleter.expect_delete().return_once(|_| {
-            Err(DeleteDeploymentError::ContainerRemove(DockerError::ServerError))
+            Err(DeleteDeploymentError::ContainerRemove(
+                DockerError::ServerError,
+            ))
         });
 
         let mut delete_command = Delete {

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -142,7 +142,6 @@ mod tests {
     use crate::interaction::mocks::MockInteraction;
     use anyhow::anyhow;
     use atlas_local::DockerError;
-    use std::io;
 
     fn create_spinner_handle() -> SpinnerHandle {
         SpinnerHandle::new(Box::new(|| {}))

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -3,7 +3,6 @@ use std::fmt::Display;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use atlas_local::{Client, DeleteDeploymentError};
-use bollard::Docker;
 use serde::Serialize;
 
 use crate::{
@@ -37,9 +36,7 @@ impl TryFrom<args::Delete> for Delete {
             force: args.force,
 
             interaction: Box::new(Interaction::new()),
-            deployment_deleter: Box::new(Client::new(
-                Docker::connect_with_defaults().context("connecting to Docker")?,
-            )),
+            deployment_deleter: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
         })
     }
 }

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -142,7 +142,7 @@ mod tests {
     use crate::interaction::SpinnerHandle;
     use crate::interaction::mocks::MockInteraction;
     use anyhow::anyhow;
-    use bollard::errors::Error as BollardError;
+    use atlas_local::DockerError;
     use std::io;
 
     fn create_spinner_handle() -> SpinnerHandle {
@@ -325,10 +325,7 @@ mod tests {
         let mut mock_deleter = MockDocker::new();
         mock_deleter.expect_delete().return_once(|_| {
             Err(DeleteDeploymentError::GetDeployment(
-                atlas_local::GetDeploymentError::from(BollardError::from(io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "deployment not found",
-                ))),
+                atlas_local::GetDeploymentError::ContainerInspect(DockerError::NotFound),
             ))
         });
 
@@ -364,9 +361,7 @@ mod tests {
 
         let mut mock_deleter = MockDocker::new();
         mock_deleter.expect_delete().return_once(|_| {
-            Err(DeleteDeploymentError::ContainerStop(BollardError::from(
-                io::Error::new(io::ErrorKind::Other, "failed to stop"),
-            )))
+            Err(DeleteDeploymentError::ContainerStop(DockerError::ServerError))
         });
 
         let mut delete_command = Delete {
@@ -401,9 +396,7 @@ mod tests {
 
         let mut mock_deleter = MockDocker::new();
         mock_deleter.expect_delete().return_once(|_| {
-            Err(DeleteDeploymentError::ContainerRemove(BollardError::from(
-                io::Error::new(io::ErrorKind::Other, "failed to remove"),
-            )))
+            Err(DeleteDeploymentError::ContainerRemove(DockerError::ServerError))
         });
 
         let mut delete_command = Delete {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -33,7 +33,9 @@ impl TryFrom<args::List> for List {
 
     fn try_from(_: args::List) -> std::result::Result<Self, Self::Error> {
         Ok(List {
-            deployment_lister: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
+            deployment_lister: Box::new(
+                Client::connect_with_defaults().context("connecting to Docker")?,
+            ),
         })
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -8,7 +8,6 @@ use std::fmt::Display;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use atlas_local::Client;
-use bollard::Docker;
 use serde::Serialize;
 
 use crate::{
@@ -34,9 +33,7 @@ impl TryFrom<args::List> for List {
 
     fn try_from(_: args::List) -> std::result::Result<Self, Self::Error> {
         Ok(List {
-            deployment_lister: Box::new(Client::new(
-                Docker::connect_with_defaults().context("connecting to Docker")?,
-            )),
+            deployment_lister: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
         })
     }
 }

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -27,7 +27,9 @@ impl TryFrom<args::Logs> for Logs {
     fn try_from(args: args::Logs) -> std::result::Result<Self, Self::Error> {
         Ok(Logs {
             deployment_name: args.deployment_name,
-            deployment_logs_retriever: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
+            deployment_logs_retriever: Box::new(
+                Client::connect_with_defaults().context("connecting to Docker")?,
+            ),
         })
     }
 }

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -7,7 +7,6 @@ use std::fmt::Display;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use atlas_local::{Client, models::LogsOptions};
-use bollard::Docker;
 use serde::Serialize;
 
 use crate::{args, commands::CommandWithOutput, dependencies::DeploymentLogsRetriever};
@@ -28,9 +27,7 @@ impl TryFrom<args::Logs> for Logs {
     fn try_from(args: args::Logs) -> std::result::Result<Self, Self::Error> {
         Ok(Logs {
             deployment_name: args.deployment_name,
-            deployment_logs_retriever: Box::new(Client::new(
-                Docker::connect_with_defaults().context("connecting to Docker")?,
-            )),
+            deployment_logs_retriever: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
         })
     }
 }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -7,7 +7,6 @@ use atlas_local::{
     client::CreateDeploymentStepOutcome,
     models::{BindingType, CreateDeploymentOptions, CreationSource, ImageTag, MongoDBPortBinding},
 };
-use bollard::Docker;
 use semver::Version;
 use serde::Serialize;
 use tracing::debug;
@@ -110,9 +109,7 @@ impl TryFrom<args::Setup> for Setup {
             connect_with: args.connect_with,
 
             interaction: Box::new(Interaction::new()),
-            deployment_management: Box::new(Client::new(
-                Docker::connect_with_defaults().context("connecting to Docker")?,
-            )),
+            deployment_management: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
             connectors: HashMap::from([
                 (
                     ConnectWith::Compass,

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -1701,9 +1701,7 @@ mod tests {
             CreateDeploymentStepOutcome::Skipped,
             CreateDeploymentStepOutcome::Skipped,
             Err(CreateDeploymentError::PullImage(
-                atlas_local::client::PullImageError::from(bollard::errors::Error::from(
-                    std::io::Error::new(std::io::ErrorKind::Other, "Failed to pull image"),
-                )),
+                atlas_local::client::PullImageError::from(atlas_local::DockerError::ServerError),
             )),
         );
         mock_deployment_management

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -109,7 +109,9 @@ impl TryFrom<args::Setup> for Setup {
             connect_with: args.connect_with,
 
             interaction: Box::new(Interaction::new()),
-            deployment_management: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
+            deployment_management: Box::new(
+                Client::connect_with_defaults().context("connecting to Docker")?,
+            ),
             connectors: HashMap::from([
                 (
                     ConnectWith::Compass,

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -7,7 +7,6 @@ use atlas_local::{
     client::WatchDeploymentError,
     models::{State, WatchOptions},
 };
-use bollard::Docker;
 use serde::Serialize;
 use tracing::{debug, info, trace};
 
@@ -50,9 +49,7 @@ impl TryFrom<args::Start> for Start {
             wait_for_healthy_timeout: args.wait_for_healthy_timeout,
 
             interaction: Box::new(Interaction::new()),
-            deployment_management: Box::new(Client::new(
-                Docker::connect_with_defaults().context("connecting to Docker")?,
-            )),
+            deployment_management: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
         })
     }
 }

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -271,7 +271,6 @@ mod tests {
         models::{Deployment as AtlasDeployment, IntoDeploymentError},
     };
     use semver::Version;
-    use std::io;
 
     fn create_spinner_handle() -> SpinnerHandle {
         SpinnerHandle::new(Box::new(|| {}))

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -270,8 +270,7 @@ mod tests {
         client::{StartDeploymentError, UnpauseDeploymentError, WatchDeploymentError},
         models::{Deployment as AtlasDeployment, IntoDeploymentError},
     };
-    use bollard::errors::Error as BollardError;
-    use bollard::secret::HealthStatusEnum;
+    use atlas_local::{ContainerHealthStatus, DockerError};
     use semver::Version;
     use std::io;
 
@@ -926,9 +925,7 @@ mod tests {
             .expect_get_deployment()
             .withf(move |name| name == &deployment_name_clone)
             .return_once(|_| {
-                Err(GetDeploymentError::ContainerInspect(BollardError::from(
-                    io::Error::new(io::ErrorKind::NotFound, "container not found"),
-                )))
+                Err(GetDeploymentError::ContainerInspect(DockerError::NotFound))
             });
 
         let mut start_command = Start {
@@ -948,7 +945,7 @@ mod tests {
             result,
             StartResult::Failed {
                 deployment_name: deployment_name.clone(),
-                error: "container not found".to_string()
+                error: "not found".to_string()
             }
         );
     }
@@ -1184,7 +1181,7 @@ mod tests {
             .return_once(|name, _| {
                 Err(WatchDeploymentError::UnhealthyDeployment {
                     deployment_name: name.to_string(),
-                    status: HealthStatusEnum::UNHEALTHY,
+                    status: ContainerHealthStatus::Unhealthy,
                 })
             });
 
@@ -1250,9 +1247,7 @@ mod tests {
                     && options.timeout_duration == Some(timeout_clone)
             })
             .return_once(|_, _| {
-                Err(WatchDeploymentError::ContainerInspect(BollardError::from(
-                    io::Error::new(io::ErrorKind::Other, "unexpected error"),
-                )))
+                Err(WatchDeploymentError::ContainerInspect(DockerError::ServerError))
             });
 
         let mut start_command = Start {

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -49,7 +49,9 @@ impl TryFrom<args::Start> for Start {
             wait_for_healthy_timeout: args.wait_for_healthy_timeout,
 
             interaction: Box::new(Interaction::new()),
-            deployment_management: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
+            deployment_management: Box::new(
+                Client::connect_with_defaults().context("connecting to Docker")?,
+            ),
         })
     }
 }
@@ -262,12 +264,12 @@ mod tests {
     use crate::dependencies::mocks::MockDocker;
     use crate::interaction::SpinnerHandle;
     use crate::interaction::mocks::MockInteraction;
+    use atlas_local::{ContainerHealthStatus, DockerError};
     use atlas_local::{
         GetDeploymentError,
         client::{StartDeploymentError, UnpauseDeploymentError, WatchDeploymentError},
         models::{Deployment as AtlasDeployment, IntoDeploymentError},
     };
-    use atlas_local::{ContainerHealthStatus, DockerError};
     use semver::Version;
     use std::io;
 
@@ -921,9 +923,7 @@ mod tests {
         mock_deployment_management
             .expect_get_deployment()
             .withf(move |name| name == &deployment_name_clone)
-            .return_once(|_| {
-                Err(GetDeploymentError::ContainerInspect(DockerError::NotFound))
-            });
+            .return_once(|_| Err(GetDeploymentError::ContainerInspect(DockerError::NotFound)));
 
         let mut start_command = Start {
             deployment_name: deployment_name.clone(),
@@ -1244,7 +1244,9 @@ mod tests {
                     && options.timeout_duration == Some(timeout_clone)
             })
             .return_once(|_, _| {
-                Err(WatchDeploymentError::ContainerInspect(DockerError::ServerError))
+                Err(WatchDeploymentError::ContainerInspect(
+                    DockerError::ServerError,
+                ))
             });
 
         let mut start_command = Start {

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -162,7 +162,7 @@ mod tests {
         client::StopDeploymentError,
         models::{Deployment as AtlasDeployment, IntoDeploymentError},
     };
-    use bollard::errors::Error as BollardError;
+    use atlas_local::DockerError;
     use semver::Version;
     use std::io;
 
@@ -498,9 +498,7 @@ mod tests {
             .expect_get_deployment()
             .withf(move |name| name == &deployment_name_clone)
             .return_once(|_| {
-                Err(GetDeploymentError::ContainerInspect(BollardError::from(
-                    io::Error::new(io::ErrorKind::NotFound, "container not found"),
-                )))
+                Err(GetDeploymentError::ContainerInspect(DockerError::NotFound))
             });
 
         let mut stop_command = Stop {
@@ -518,7 +516,7 @@ mod tests {
             result,
             StopResult::Failed {
                 deployment_name: deployment_name.clone(),
-                error: "container not found".to_string()
+                error: "not found".to_string()
             }
         );
     }

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -32,7 +32,9 @@ impl TryFrom<args::Stop> for Stop {
             deployment_name: args.deployment_name,
 
             interaction: Box::new(Interaction::new()),
-            deployment_management: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
+            deployment_management: Box::new(
+                Client::connect_with_defaults().context("connecting to Docker")?,
+            ),
         })
     }
 }
@@ -154,12 +156,12 @@ mod tests {
     use crate::dependencies::mocks::MockDocker;
     use crate::interaction::SpinnerHandle;
     use crate::interaction::mocks::MockInteraction;
+    use atlas_local::DockerError;
     use atlas_local::{
         GetDeploymentError,
         client::StopDeploymentError,
         models::{Deployment as AtlasDeployment, IntoDeploymentError},
     };
-    use atlas_local::DockerError;
     use semver::Version;
     use std::io;
 
@@ -494,9 +496,7 @@ mod tests {
         mock_deployment_management
             .expect_get_deployment()
             .withf(move |name| name == &deployment_name_clone)
-            .return_once(|_| {
-                Err(GetDeploymentError::ContainerInspect(DockerError::NotFound))
-            });
+            .return_once(|_| Err(GetDeploymentError::ContainerInspect(DockerError::NotFound)));
 
         let mut stop_command = Stop {
             deployment_name: deployment_name.clone(),

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -163,7 +163,6 @@ mod tests {
         models::{Deployment as AtlasDeployment, IntoDeploymentError},
     };
     use semver::Version;
-    use std::io;
 
     fn create_spinner_handle() -> SpinnerHandle {
         SpinnerHandle::new(Box::new(|| {}))

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -3,7 +3,6 @@ use std::fmt::Display;
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use atlas_local::{Client, models::State};
-use bollard::Docker;
 use serde::Serialize;
 use tracing::{debug, trace};
 
@@ -33,9 +32,7 @@ impl TryFrom<args::Stop> for Stop {
             deployment_name: args.deployment_name,
 
             interaction: Box::new(Interaction::new()),
-            deployment_management: Box::new(Client::new(
-                Docker::connect_with_defaults().context("connecting to Docker")?,
-            )),
+            deployment_management: Box::new(Client::connect_with_defaults().context("connecting to Docker")?),
         })
     }
 }

--- a/src/commands/with_mongodb.rs
+++ b/src/commands/with_mongodb.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use bollard::Docker;
 use mongodb::{
     Client,
     options::{ClientOptions, ConnectionString, Credential},
@@ -71,11 +70,9 @@ async fn try_get_mongodb_client_for_local_deployment(
     password: Option<String>,
 ) -> Result<Client, TryToGetMongodbClientError> {
     // Connect to docker and create a new client.
-    let client = atlas_local::Client::new(
-        Docker::connect_with_defaults()
-            .context("connecting to docker")
-            .map_err(TryToGetMongodbClientError::ConnectingToDocker)?,
-    );
+    let client = atlas_local::Client::connect_with_defaults()
+        .context("connecting to docker")
+        .map_err(TryToGetMongodbClientError::ConnectingToDocker)?;
 
     // Get the connection string for the local deployment.
     let connection_string = client


### PR DESCRIPTION
## Summary

- Bumps `atlas-local` 0.6.1 → 0.7.1 (released 2026-05-26)
- Drops the direct `bollard` dependency — the CLI no longer imports bollard directly
- Includes all other dependency bumps from dependabot PR #67

## Root cause

Dependabot PR #67 bumped bollard to 0.20.2, which made `bollard::secret::*` types private. `atlas-local` 0.6.1 used those types in its public API, causing build failures across all platforms.

## Fix

`atlas-local` 0.7.1 removes bollard from its public API:
- `DockerError` replaces `bollard::errors::Error`
- `ContainerHealthStatus` replaces `bollard::secret::HealthStatusEnum`
- `Client::connect_with_defaults()` / `Client::connect_with_socket_defaults()` replace `Client::new(Docker::connect_with_defaults()?)`
- bollard is re-exported as `atlas_local::bollard` for users who need it directly

`atlas-local` 0.7.x requires bollard 0.21 (not 0.20), but since the CLI no longer imports bollard directly, bollard is now a transitive dependency only.

## Changes

- `Cargo.toml`: bump `atlas-local` to 0.7.1, remove direct `bollard` dep, apply all other bumps from PR #67
- `start.rs`, `connect.rs`, `stop.rs`, `delete.rs`, `setup.rs`: replace `bollard::errors::Error` / `bollard::secret::HealthStatusEnum` in test code with `atlas_local::DockerError` / `atlas_local::ContainerHealthStatus`
- `start.rs`, `stop.rs`, `delete.rs`, `connect.rs`, `setup.rs`, `list.rs`, `logs.rs`, `with_mongodb.rs`: replace `Client::new(Docker::connect_with_defaults()?)` with `Client::connect_with_defaults()`, remove `use bollard::Docker` imports

## Test plan

- [x] `cargo check` passes
- [x] All 161 unit tests pass (`cargo test`)

## Jira

- https://jira.mongodb.org/browse/CLOUDP-408340 (CLI: bump atlas-local to 0.7.1, drop direct bollard dependency)
- https://jira.mongodb.org/browse/CLOUDP-372198 (lib: stop leaking bollard types in public API)

Closes #67