### PR TITLE
fix(deps): update crossbeam-epoch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y curl gcc libdbus-1-dev
+          apt-get install -y curl gcc libc6-dev libdbus-1-dev
       
       - name: Install Atlas CLI
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -5355,7 +5355,7 @@ limitations under the License.
         - critical-section 1.2.0 (https://github.com/rust-embedded/critical-section)
         - crossbeam-channel 0.5.15 (https://github.com/crossbeam-rs/crossbeam)
         - crossbeam-deque 0.8.6 (https://github.com/crossbeam-rs/crossbeam)
-        - crossbeam-epoch 0.9.18 (https://github.com/crossbeam-rs/crossbeam)
+        - crossbeam-epoch 0.9.20 (https://github.com/crossbeam-rs/crossbeam)
         - crossbeam-utils 0.8.21 (https://github.com/crossbeam-rs/crossbeam)
         - dbus-secret-service 4.1.0 (https://github.com/brotskydotcom/dbus-secret-service.git)
         - derive-syn-parse 0.2.0 (https://github.com/sharnoff/derive-syn-parse)


### PR DESCRIPTION
## Summary
- Update `crossbeam-epoch` from `0.9.18` to `0.9.20`
- Resolve RUSTSEC-2026-0204

## Verification
- `cargo deny check`
- `cargo audit --deny warnings`
- `cargo fmt --all`
- `cargo clippy --all-targets`
- `cargo test --all-targets`

Closes CLOUDP-429487